### PR TITLE
Improve the hash functions used in count.go:hashn()

### DIFF
--- a/count.go
+++ b/count.go
@@ -2,6 +2,7 @@ package probably
 
 import (
 	"fmt"
+	"hash/fnv"
 	"math"
 )
 
@@ -27,19 +28,27 @@ func (s Sketch) String() string {
 }
 
 func hashn(s string, d, lim int) []int {
-	hval := uint32(0)
+
+	fnv1a := fnv.New32a()
+	fnv1a.Write([]byte(s))
+	h1 := fnv1a.Sum32()
+
+	// inlined jenkins one-at-a-time hash
+	h2 := uint32(0)
 	for _, c := range s {
-		hval = (hval << 3) ^ hval ^ uint32(c)
+		h2 += uint32(c)
+		h2 += h2 << 10
+		h2 ^= h2 >> 6
 	}
+	h2 += (h2 << 3)
+	h2 ^= (h2 >> 11)
+	h2 += (h2 << 15)
 
 	rv := make([]int, 0, d)
 
 	for i := 0; i < d; i++ {
-		h2 := hval + uint32(i)
-		h2 += (h2 << 10)
-		h2 ^= (h2 >> 6)
-
-		h := int(h2) % lim
+		h := int(h1) + i*int(h2)
+		h %= lim
 		if h < 0 {
 			h = 0 - h
 		}


### PR DESCRIPTION
This patch improves hashn to use fnv1a and Jenkins' one-at-a-time to
simulate 'd' independent hash functions.  This contruction is validated
by the paper at: http://www.eecs.harvard.edu/~kirsch/pubs/bbbf/esa06.pdf
[ "Less Hashing, Same Performance: Building a Better Bloom Filter" ,
Kirsch & Mitzenmacher (2006) ]

This also fixes a problem with the current implementation where counts
would be off for any strings which collided on the first hash function.
