### PR TITLE
Switch 'topk'  counter to conservative increments

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -74,7 +74,7 @@ func (s *StreamTop) trim() {
 
 // Add an item to the stream counter.
 func (s *StreamTop) Add(v string) {
-	count := s.sk.Increment(v)
+	count := s.sk.ConservativeIncrement(v)
 	if count > s.thresh {
 		s.keys[v] = count
 	}


### PR DESCRIPTION
The count-min conservative increment gives more accurate counts at the
cost of not being able to delete from the sketch.  Since we can't delete
from the sketch while implementing 'topk' counting, here the trade-off
is worth it.
