### PR TITLE
count: implement count-mean-min estimation

### DIFF
--- a/count.go
+++ b/count.go
@@ -4,10 +4,14 @@ import (
 	"fmt"
 	"hash/fnv"
 	"math"
+	"sort"
 )
 
 // A count-min sketcher.
-type Sketch [][]uint32
+type Sketch struct {
+	sk        [][]uint32
+	rowCounts []uint32
+}
 
 // Create a new count-min sketch with the given width and depth.
 func NewSketch(w, d int) *Sketch {
@@ -15,16 +19,20 @@ func NewSketch(w, d int) *Sketch {
 		panic("Dimensions must be positive")
 	}
 
-	rv := make(Sketch, d)
+	s := &Sketch{}
+
+	s.sk = make([][]uint32, d)
 	for i := 0; i < d; i++ {
-		rv[i] = make([]uint32, w)
+		s.sk[i] = make([]uint32, w)
 	}
 
-	return &rv
+	s.rowCounts = make([]uint32, d)
+
+	return s
 }
 
 func (s Sketch) String() string {
-	return fmt.Sprintf("{Sketch %dx%d}", len(s[0]), len(s))
+	return fmt.Sprintf("{Sketch %dx%d}", len(s.sk[0]), len(s.sk))
 }
 
 func hashn(s string, d, lim int) []int {
@@ -60,12 +68,13 @@ func hashn(s string, d, lim int) []int {
 
 // Add 'count' occurences of the given input
 func (s *Sketch) Add(h string, count uint32) (val uint32) {
-	w := len((*s)[0])
-	d := len(*s)
+	w := len(s.sk[0])
+	d := len(s.sk)
 	val = math.MaxUint32
 	for i, pos := range hashn(h, d, w) {
-		v := (*s)[i][pos] + count
-		(*s)[i][pos] = v
+		s.rowCounts[i] += count
+		v := s.sk[i][pos] + count
+		s.sk[i][pos] = v
 		if v < val {
 			val = v
 		}
@@ -75,15 +84,16 @@ func (s *Sketch) Add(h string, count uint32) (val uint32) {
 
 // Delete 'count' occurences of the given input
 func (s *Sketch) Del(h string, count uint32) (val uint32) {
-	w := len((*s)[0])
-	d := len(*s)
+	w := len(s.sk[0])
+	d := len(s.sk)
 	val = math.MaxUint32
 	for i, pos := range hashn(h, d, w) {
-		v := (*s)[i][pos] - count
-		if v > (*s)[i][pos] { // did we wrap-around?
+		s.rowCounts[i] -= count
+		v := s.sk[i][pos] - count
+		if v > s.sk[i][pos] { // did we wrap-around?
 			v = 0
 		}
-		(*s)[i][pos] = v
+		s.sk[i][pos] = v
 		if v < val {
 			val = v
 		}
@@ -96,7 +106,6 @@ func (s *Sketch) Increment(h string) (val uint32) {
 	return s.Add(h, 1)
 }
 
-
 // Increment the count (conservatively) for the given input.
 func (s *Sketch) ConservativeIncrement(h string) (val uint32) {
 	return s.ConservativeAdd(h, 1)
@@ -104,13 +113,13 @@ func (s *Sketch) ConservativeIncrement(h string) (val uint32) {
 
 // Add the count (conservatively) for the given input.
 func (s *Sketch) ConservativeAdd(h string, count uint32) (val uint32) {
-	w := len((*s)[0])
-	d := len(*s)
+	w := len(s.sk[0])
+	d := len(s.sk)
 	hashes := hashn(h, d, w)
 
 	val = math.MaxUint32
 	for i, pos := range hashes {
-		v := (*s)[i][pos]
+		v := s.sk[i][pos]
 		if v < val {
 			val = v
 		}
@@ -124,9 +133,10 @@ func (s *Sketch) ConservativeAdd(h string, count uint32) (val uint32) {
 	// traffic measurement and accounting. SIGCOMM Comput. Commun. Rev., 32(4).
 
 	for i, pos := range hashes {
-		v := (*s)[i][pos]
+		v := s.sk[i][pos]
 		if v < val {
-			(*s)[i][pos] = val
+			s.rowCounts[i] += (val - s.sk[i][pos])
+			s.sk[i][pos] = val
 		}
 	}
 	return val
@@ -135,10 +145,10 @@ func (s *Sketch) ConservativeAdd(h string, count uint32) (val uint32) {
 // Get the estimate count for the given input.
 func (s Sketch) Count(h string) uint32 {
 	var min uint32 = math.MaxUint32
-	w := len(s[0])
-	d := len(s)
+	w := len(s.sk[0])
+	d := len(s.sk)
 	for i, pos := range hashn(h, d, w) {
-		v := s[i][pos]
+		v := s.sk[i][pos]
 		if v < min {
 			min = v
 		}
@@ -146,15 +156,68 @@ func (s Sketch) Count(h string) uint32 {
 	return min
 }
 
+/*
+   CountMinMean described in:
+   Fan Deng and Davood Raﬁei. 2007. New estimation algorithms for streaming data: Count-min can do more.
+   http://webdocs.cs.ualberta.ca/~fandeng/paper/cmm.pdf
+
+   Sketch Algorithms for Estimating Point Queries in NLP
+   Amit Goyal, Hal Daume III and Graham Cormode
+   EMNLP-CONLL 2012
+   http://www.umiacs.umd.edu/~amit/Papers/goyalPointQueryEMNLP12.pdf
+*/
+
+// Get the estimate count for the given input, using the count-min-mean
+// heuristic.  This gives more accurate results than Count() for low-frequency
+// counts at the cost of larger under-estimation error.  For tasks sensitive to
+// under-estimation, use the regular Count() and only call ConservativeAdd()
+// and ConservativeIncrement() when constructing your sketch.
+func (s Sketch) CountMinMean(h string) uint32 {
+	var min uint32 = math.MaxUint32
+	w := len(s.sk[0])
+	d := len(s.sk)
+	residues := make([]float64, d)
+	for i, pos := range hashn(h, d, w) {
+		v := s.sk[i][pos]
+		noise := float64(s.rowCounts[i]-s.sk[i][pos]) / float64(w-1)
+		residues[i] = float64(v) - noise
+		// negative count doesn't make sense
+		if residues[i] < 0 {
+			residues[i] = 0
+		}
+		if v < min {
+			min = v
+		}
+	}
+
+	sort.Float64s(residues)
+	var median uint32
+	if d%2 == 1 {
+		median = uint32(residues[(d+1)/2])
+	} else {
+		// integer average without overflow
+		x := uint32(residues[d/2])
+		y := uint32(residues[d/2+1])
+		median = (x & y) + (x^y)/2
+	}
+
+	// count estimate over the upper-bound (min) doesn't make sense
+	if min < median {
+		return min
+	}
+
+	return median
+}
+
 // Merge the given sketch into this one.
 func (s *Sketch) Merge(from *Sketch) {
-	if len(*s) != len(*from) || len((*s)[0]) != len((*from)[0]) {
+	if len(s.sk) != len(from.sk) || len(s.sk[0]) != len(from.sk[0]) {
 		panic("Can't merge different sketches with different dimensions")
 	}
 
-	for i, l := range *from {
+	for i, l := range from.sk {
 		for j, v := range l {
-			(*s)[i][j] += v
+			s.sk[i][j] += v
 		}
 	}
 }


### PR DESCRIPTION
This commit adds count-min-mean estimation ( described in http://webdocs.cs.ualberta.ca/~fandeng/paper/cmm.pdf ) which produces better results for low-frequency items at the risk of larger under-estimation error.
