### PR TITLE
Correct statement on sketch error bounds.

### DIFF
--- a/count.go
+++ b/count.go
@@ -15,7 +15,7 @@ type Sketch struct {
 
 // NewSketch returns new count-min sketch with the given width and depth.
 // Sketch dimensions must be positive.  A sketch with w=⌈ ℯ/𝜀 ⌉ and
-// d=⌈ln (1/𝛿)⌉ answers queries within a factor of 𝜀 with probability 𝛿 .
+// d=⌈ln (1/𝛿)⌉ answers queries within a factor of 𝜀 with probability 1-𝛿.
 func NewSketch(w, d int) *Sketch {
 	if d < 1 || w < 1 {
 		panic("Dimensions must be positive")


### PR DESCRIPTION
delta is the probability of the error exceeding epsilon, so the complement is the probability of being within epsilon.

It's a small mistake but I happened to notice it and it could be confusing to someone who is unfamiliar. An easy way to verify- rearrange `d  = ceil(1/delta)` to `delta ~= exp(-d)`. Increasing the number of rows should decrease the error, and increasing d decreases delta.   